### PR TITLE
Make non owned token moving work when there are multiple GM accounts.

### DIFF
--- a/src/IRtoken/IRtoken.js
+++ b/src/IRtoken/IRtoken.js
@@ -171,7 +171,7 @@ export class IRtoken {
                 let payload = {
                     "msgType": "moveToken",
                     "senderId": game.user.id, 
-                    "receiverId": game.data.users.find(users => users.role == 4)._id, 
+                    "receiverId": game.users.activeGM._id,
                     "tokenId": this.token.id,
                     "newCoords": newCoords
                 };
@@ -292,7 +292,7 @@ export class IRtoken {
                 let payload = {
                     "msgType": "moveToken",
                     "senderId": game.user.id, 
-                    "receiverId": game.data.users.find(users => users.role == 4)._id, 
+                    "receiverId": game.users.activeGM._id,
                     "tokenId": this.token.id,
                     "newCoords": newCoords
                 };


### PR DESCRIPTION
In my setup, there are 2 accounts with GM permissions, and both are not necessarily logged in during play. This changes it so it finds a logged in GM account.