### PR TITLE
Make MaterialPlane work properly in non full screen windows.

### DIFF
--- a/src/IRtoken/tokenHelpers.js
+++ b/src/IRtoken/tokenHelpers.js
@@ -25,16 +25,16 @@ export function scaleIRinput(coords){
     if (coords.x > 4095) coords.x = 4095;
     if (coords.y < 0) coords.y = 0;
     if (coords.y > 4095) coords.y = 4095;
-  
-    //Calculate the amount of pixels that are visible on the screen
-    const horVisible = screen.width/canvas.scene._viewPosition.scale;
-    const vertVisible = screen.height/canvas.scene._viewPosition.scale;
+
+    //Calculate the amount of pixels that are visible in the screen window
+    const horVisible = window.innerWidth/canvas.scene._viewPosition.scale;
+    const vertVisible = window.innerHeight/canvas.scene._viewPosition.scale;
   
     //Calculate the scaled coordinates
     const posX = (coords.x/4096)*horVisible+canvas.scene._viewPosition.x-horVisible/2;
     const posY = (coords.y/4096)*vertVisible+canvas.scene._viewPosition.y-vertVisible/2;
   
-    debug('cal',`Raw: (${Math.round(coords.x)}, ${Math.round(coords.y)}). Scaled: (${Math.round(posX)}, ${Math.round(posY)}). View: (${Math.round(canvas.scene._viewPosition.x)}, ${Math.round(canvas.scene._viewPosition.y)}, ${canvas.scene._viewPosition.scale}). Canvas: ${canvas.dimensions.width}x${canvas.dimensions.height} (${canvas.dimensions.rect.x}, ${canvas.dimensions.rect.y}). Scene: ${canvas.dimensions.sceneWidth}x${canvas.dimensions.sceneHeight} (${canvas.dimensions.sceneRect.x}, ${canvas.dimensions.sceneRect.y}). Display: ${screen.width}x${screen.height}`)
+    debug('cal',`Raw: (${Math.round(coords.x)}, ${Math.round(coords.y)}). Scaled: (${Math.round(posX)}, ${Math.round(posY)}). View: (${Math.round(canvas.scene._viewPosition.x)}, ${Math.round(canvas.scene._viewPosition.y)}, ${canvas.scene._viewPosition.scale}). Canvas: ${canvas.dimensions.width}x${canvas.dimensions.height} (${canvas.dimensions.rect.x}, ${canvas.dimensions.rect.y}). Scene: ${canvas.dimensions.sceneWidth}x${canvas.dimensions.sceneHeight} (${canvas.dimensions.sceneRect.x}, ${canvas.dimensions.sceneRect.y}). Display: ${window.innerWidth}x${window.innerHeight}`)
   
     //Return the value
     return {"x":Math.round(posX),"y":Math.round(posY)};

--- a/src/calibration.js
+++ b/src/calibration.js
@@ -525,13 +525,10 @@ export class calibrationOverlay extends ControlsLayer {
 
     update() {
         if (document.getElementById("mpCalError")) {
-            //Check if window is fullscreen
-            const isNotFullScreen = screen.width != window.innerWidth || screen.height != window.innerHeight;
-                    
             //Check for browser zoom or display scaling
             const isScaled = window.devicePixelRatio != 1;
 
-            if (isNotFullScreen || isScaled) 
+            if (isScaled)
                 document.getElementById("mpCalError").style.display = "";
             else
                 document.getElementById("mpCalError").style.display = "none";
@@ -540,9 +537,9 @@ export class calibrationOverlay extends ControlsLayer {
         }
         
 
-        //Calculate the amount of pixels that are visible on the screen
-        const horVisible = screen.width/canvas.scene._viewPosition.scale;
-        const vertVisible = screen.height/canvas.scene._viewPosition.scale;
+        //Calculate the amount of pixels that are visible on the screen/in the window
+        const horVisible = window.innerWidth/canvas.scene._viewPosition.scale;
+        const vertVisible = window.innerHeight/canvas.scene._viewPosition.scale;
 
         const x = canvas.scene._viewPosition.x;
         let y = canvas.scene._viewPosition.y;


### PR DESCRIPTION
This should not affect full screen operation, as in that case, the width of the window and width of the screen should be the same (and is what MaterialPlane is actually checking to see if in full screen mode).  I can't think of cases where there would be a mismatch like this when running fullscreen, and if so, I'm not sure if the screen vs window values would be the correct ones to use regardless, but this probably needs more testing in various scenarios.
