### PR TITLE
Allow toggling secure websockets

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -59,6 +59,8 @@
     "MaterialPlane.Config.ConnectionModeNoConnect": "Don't Connect",
     "MaterialPlane.Config.MaxAttempts": "Maximum Connection Attempts",
     "MaterialPlane.Config.MaxAttempts_Hint": "The maximum amount of times Material Plane will attempt to connect to the sensor or Material Companion.",
+    "MaterialPlane.Config.SecureWebsockets": "Use Secure Websockets",
+    "MaterialPlane.Config.SecureWebsockets_Hint": "If checked, connect using Secure Websockets.  Note that there is no built in mechanism to provide secure websockets in the Material Plane hardware or Material Companion.  A secured proxy must be provided by the user.",
 
     "MaterialPlane.Config.TapMode": "Touch Mode",
     "MaterialPlane.Config.TapMode_Hint": "Sets the touch mode. This can be used to distinguish between touches caused by minis and taps that are meant to interact with the canvas (such as opening doors). 'Tap Timeout': When a new touch is detected, a timer will start. If the touch is removed before the timer is bigger than 'Tap Timeout', MP will assume it was a tap. Otherwise it'll assume a mini was placed. Token movement will start after 'Tap Timeout' has elapsed. 'Raise Mini': When a new touch is detected, MP will check if a touch has recently (within the last 'Tap Timeout' ms) ended near the new touch. It that's the case, MP will assume a mini is being moved, otherwise it'll assume a tap.",

--- a/src/Communication/websocket.js
+++ b/src/Communication/websocket.js
@@ -10,6 +10,8 @@ let wsInterval;                 //Interval timer to detect disconnections
 let disableTimeout = false;
 let connectFailedMsg = false;
 let connectionAttempts = 0;
+let secureWebsockets = false;
+let websocketProtocol = "ws"
 
 /**
  * Analyzes the message received from the IR tracker.-
@@ -91,8 +93,10 @@ async function analyzeWSmessage(msg,passthrough = false){
 export async function startWebsocket() {
     
     ip = game.settings.get(moduleName,'ConnectionMode') == 'materialCompanion' ? game.settings.get(moduleName,'MaterialServerIP') : game.settings.get(moduleName,'IP');
-    console.log(`Material Plane: Starting websocket on 'ws://${ip}'`);
-    ws = new WebSocket('ws://'+ip);
+    secureWebsockets = game.settings.get(moduleName,'secureWebsockets');
+    if (secureWebsockets) websocketProtocol = "wss";
+    console.log(`Material Plane: Starting websocket on '${websocketProtocol}://${ip}'`);
+    ws = new WebSocket(websocketProtocol+'://'+ip);
     
     clearInterval(wsInterval);
 

--- a/src/Misc/config.js
+++ b/src/Misc/config.js
@@ -214,7 +214,7 @@ export class mpConfig extends FormApplication {
             document.getElementById("mpConnAttemptsNumber").value = val;
             this.setSettings('nrOfConnAttempts',val);
         });
-        html.find("input[id=mpSecureWebsockets]").on('change', event => { this.setSettings('secureWebsockets',event.target.checked); });
+        html.find("input[id=mpSecureWebsockets]").on('change', event => { this.setSettings('secureWebsockets',event.target.checked); this.restart = true; });
 
         // --- Touch settings ---
         html.find("select[id=mpTapMode]").on('change', event =>         { this.setSettings('tapMode',event.target.value); });

--- a/src/Misc/config.js
+++ b/src/Misc/config.js
@@ -73,6 +73,7 @@ export class mpConfig extends FormApplication {
             sensorIP: game.settings.get(moduleName,'IP'),
             materialServerIP: game.settings.get(moduleName,'MaterialServerIP'),
             nrOfConnAttempts: game.settings.get(moduleName,'nrOfConnAttempts'),
+            secureWebsockets: game.settings.get(moduleName,'secureWebsockets'),
 
             tapMode: game.settings.get(moduleName,'tapMode'),
             touchTimeout: game.settings.get(moduleName,'touchTimeout'),
@@ -213,6 +214,7 @@ export class mpConfig extends FormApplication {
             document.getElementById("mpConnAttemptsNumber").value = val;
             this.setSettings('nrOfConnAttempts',val);
         });
+        html.find("input[id=mpSecureWebsockets]").on('change', event => { this.setSettings('secureWebsockets',event.target.checked); });
 
         // --- Touch settings ---
         html.find("select[id=mpTapMode]").on('change', event =>         { this.setSettings('tapMode',event.target.value); });

--- a/src/Misc/settings.js
+++ b/src/Misc/settings.js
@@ -239,6 +239,16 @@ export const registerSettings = function() {
         type: String
     });
 
+    /**
+     * Secure Websockets
+     */
+    game.settings.register(moduleName,'secureWebsockets', {
+        scope: "client",
+        config: false,
+        default: false,
+        type: Boolean
+    });
+
     //invisible settings
     game.settings.register(moduleName,'menuOpen', {
         scope: "client",

--- a/templates/config.html
+++ b/templates/config.html
@@ -275,6 +275,16 @@
                 </div>
             </div>
 
+            <!-- Use Secure Websockets -->
+            <div class="mpConfigFormElements" id="mpSecureWebsockets">
+                <label class="mpTooltip">{{localize "MaterialPlane.Config.SecureWebsockets"}}*
+                    <span class="mpTooltiptext">{{localize "MaterialPlane.Config.SecureWebsockets_Hint"}}</span>
+                </label>
+                <div class="mpConfigFormVal">
+                    <input type="checkbox" id="mpSecureWebsockets" {{#if secureWebsockets}}checked{{/if}}>
+                </div>
+            </div>
+
             <!-- Number of connections attempts -->
             <div class="mpConfigFormElements">
                 <label class="mpTooltip">{{localize "MaterialPlane.Config.MaxAttempts"}}


### PR DESCRIPTION
Start of implementation of https://github.com/MaterialFoundry/MaterialPlane/issues/7.  Provides a toggle for the user to enable wss, if they have a means to provide a secured proxy.

I've tested this via an nginx proxy with Let's Encrypt-provided certs, which forwards to the backing server running in the companion.  Realistically, I could probably bypass companion at this point, but I haven't actually tested that.